### PR TITLE
Fix fastboot support in one-way-input-mask#didReceiveAttrs

### DIFF
--- a/addon/components/one-way-input-mask.js
+++ b/addon/components/one-way-input-mask.js
@@ -102,6 +102,7 @@ const OneWayInputMask = Component.extend({
 
   didInsertElement() {
     this._setupMask();
+    set(this, '_didInsertElement', true);
   },
 
   didReceiveAttrs() {
@@ -230,7 +231,7 @@ const OneWayInputMask = Component.extend({
    * @private
    */
   _changeMask() {
-    if (this.element && this.element.inputmask) {
+    if (get(this, '_didInsertElement') && this.element && this.element.inputmask) {
       this._destroyMask();
       this._setupMask();
     }


### PR DESCRIPTION
This is just a minor change to ensure that fastboot apps can render pages with `one-way-input-mask`s on them.

Here is the error I was getting when trying to use something very simple like `{{one-way-input-mask val mask='a-9-a-9'}}`

```
There was an error running your app in fastboot. More info about the error:
  Error: Accessing `this.element` is not allowed in non-interactive environments (such as FastBoot).
```

I think the right approach might be to schedule the `_changeMask` hook to run `afterRender` or something like that. I'm only submitting what I've got working for now in case anyone else is running into this issue.

It might be good to make sure all the things that touch `this.element` are protected behind something like this so that this issue wouldn't reappear if any of these private methods end up being called in the fastboot lifecycle hooks. What do you think?

P.S. Thanks for writing this great wrapper library and documenting it so well in the code :)